### PR TITLE
Cleanup distribution selection and reduce the number of conversions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,56 +40,55 @@ module.exports = {
     });
   },
 
-  addKnownRuntimes(testFiles, runtimeStats) {
-    return testFiles.map(function({ path, size }) {
-      return { path, size, runtime: runtimeStats.get(path) };
-    });
+  attachRuntimesToFiles(testFiles, runtimeStats) {
+    for (const info of testFiles) {
+      info.runtime = runtimeStats.get(info.path) || 0;
+    }
+
+    return testFiles;
   },
 
   distributeByRuntime({ testFiles, runtimeStats, totalGroups }) {
-    const filesWithStats = module.exports.addKnownRuntimes(
+    const filesWithStats = module.exports.attachRuntimesToFiles(
       testFiles,
       runtimeStats
     );
 
-    const filesWithMissingRuntimes = filesWithStats.filter(function({
-      runtime
-    }) {
-      return typeof runtime === "undefined";
-    });
+    const filesWithMissingRuntimes = filesWithStats.filter(
+      file => file.runtime === 0
+    );
 
-    let backlog;
+    let propertyToCompare;
     if (filesWithMissingRuntimes.length / filesWithStats.length > 0.1) {
-      backlog = filesWithStats.map(function(f) {
-        return [f.path, f.size];
-      });
+      propertyToCompare = "size";
     } else {
-      backlog = filesWithStats.map(function(f) {
-        return [f.path, f.runtime || 0];
-      });
+      propertyToCompare = "runtime";
     }
 
-    const sortedFilesWithStats = backlog.sort((a, b) => b[1] - a[1]);
+    const sortedFilesWithStats = filesWithStats.sort((a, b) => {
+      return b[propertyToCompare] - a[propertyToCompare];
+    });
 
     function createBuckets(totalGroups) {
       const buckets = [];
       for (let i = 0; i < totalGroups; i++) {
-        buckets.push({ size: 0, files: [] });
+        buckets.push({ size: 0, runtime: 0, files: [] });
       }
       return buckets;
     }
 
-    function nextBucket(buckets) {
-      const minBucketSize = Math.min(...buckets.map(b => b.size));
-      return buckets.find(bucket => bucket.size === minBucketSize);
+    function nextBucketBy(property, buckets) {
+      const mininumPropertyValue = Math.min(...buckets.map(b => b[property]));
+      return buckets.find(bucket => bucket[property] === mininumPropertyValue);
     }
 
     const buckets = createBuckets(totalGroups);
     for (let i = 0; i < sortedFilesWithStats.length; i++) {
-      const [file, size] = sortedFilesWithStats[i];
-      const bucket = nextBucket(buckets);
+      const bucket = nextBucketBy(propertyToCompare, buckets);
+      const { path, size, runtime } = sortedFilesWithStats[i];
       bucket.size += size;
-      bucket.files.push(file);
+      bucket.runtime += runtime;
+      bucket.files.push(path);
     }
     return buckets;
   }

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -8,6 +8,7 @@ Array [
       "2",
       "1",
     ],
+    "runtime": 300,
     "size": 12,
   },
   Object {
@@ -15,6 +16,7 @@ Array [
       "8",
       "3",
     ],
+    "runtime": 1100,
     "size": 11,
   },
   Object {
@@ -22,6 +24,7 @@ Array [
       "7",
       "4",
     ],
+    "runtime": 1100,
     "size": 11,
   },
   Object {
@@ -29,6 +32,7 @@ Array [
       "6",
       "5",
     ],
+    "runtime": 1100,
     "size": 11,
   },
 ]
@@ -38,34 +42,37 @@ exports[`index distributeByRuntime when more than 90% of runtime stats are avail
 Array [
   Object {
     "files": Array [
-      "10",
-      "3",
-      "2",
-    ],
-    "size": 1500,
-  },
-  Object {
-    "files": Array [
       "9",
-      "4",
+      "2",
       "1",
     ],
-    "size": 1400,
+    "runtime": 1200,
+    "size": 12,
   },
   Object {
     "files": Array [
       "8",
-      "5",
-      "11",
+      "3",
+      "10",
     ],
-    "size": 1300,
+    "runtime": 1100,
+    "size": 21,
   },
   Object {
     "files": Array [
       "7",
-      "6",
+      "4",
     ],
-    "size": 1300,
+    "runtime": 1100,
+    "size": 11,
+  },
+  Object {
+    "files": Array [
+      "6",
+      "5",
+    ],
+    "runtime": 1100,
+    "size": 11,
   },
 ]
 `;

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -3,7 +3,7 @@
 const {
   listFiles,
   loadRuntimeStats,
-  addKnownRuntimes,
+  attachRuntimesToFiles,
   distributeByRuntime
 } = require("../lib/index");
 
@@ -57,10 +57,10 @@ describe("index", function() {
         .set("test/1.spec.js", 100)
         .set("test/2.spec.js", 200)
         .set("test/4.spec.js", 400);
-      expect(addKnownRuntimes(testFiles, runtimeStats)).toEqual([
+      expect(attachRuntimesToFiles(testFiles, runtimeStats)).toEqual([
         { path: "test/1.spec.js", size: 1, runtime: 100 },
         { path: "test/2.spec.js", size: 2, runtime: 200 },
-        { path: "test/3.spec.js", size: 3, runtime: undefined }
+        { path: "test/3.spec.js", size: 3, runtime: 0 }
       ]);
     });
   });
@@ -77,8 +77,7 @@ describe("index", function() {
           .set("6", 600)
           .set("7", 700)
           .set("8", 800)
-          .set("9", 900)
-          .set("10", 1000);
+          .set("9", 900);
         const testFiles = [
           { path: "1", size: 1 },
           { path: "2", size: 2 },
@@ -89,8 +88,7 @@ describe("index", function() {
           { path: "7", size: 7 },
           { path: "8", size: 8 },
           { path: "9", size: 9 },
-          { path: "10", size: 10 },
-          { path: "11", size: 11 }
+          { path: "10", size: 10 }
         ];
         const result = distributeByRuntime({
           testFiles,


### PR DESCRIPTION
Maintain both runtime and size counts in the final result. When
choosing which property to bucket, choose an object property to
use for the sorting and bucket comparison up front and then use
it everywhere.

Including both runtime/size starts in the bucket totals has made
it easier to spot which one is in use and the snapshot.